### PR TITLE
Use passive flag for all events

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@
     if ('ontouchstart' in window) {
       window.addEventListener('touchstart', onPointerDown, options)
     }
-    window.addEventListener('keydown', onKeyDown, useCapture)
-    window.addEventListener('focusin', updateDoc, useCapture)
+    window.addEventListener('keydown', onKeyDown, options)
+    window.addEventListener('focusin', updateDoc, options)
   }
 
   const onPointerDown = () => {


### PR DESCRIPTION
For performance reasons, use passive flag for all listening events.